### PR TITLE
Implement sticky footer using flexbox

### DIFF
--- a/lib/static/css/main.css
+++ b/lib/static/css/main.css
@@ -1834,3 +1834,27 @@ footer .copyright {
     display: none;
   }
 }
+
+@media screen and (min-width: 736px) {
+  body {
+    display: flex;
+    flex-direction: column;
+  }
+  .fixedHeaderContainer {
+    flex-shrink: 0;
+  }
+  .navPusher {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+    padding-top: 50px;
+  }
+  .docMainWrapper {
+    flex-grow: 1;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  footer.nav-footer {
+    flex-shrink: 0;
+  }
+}


### PR DESCRIPTION
Implemented the solution provided [here](https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/) to allow the footer to stick downward no matter how much content the page contain.

## Motivation

Have a footer hanging above with a space below when not enough content is added is something that bothers everyone. Implementing that behavior on desktop is simple and progressively enhance the look of the website on new browsers.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/Docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This is a UI change affecting only the main stylesheet. I have tested the solution on the latest versions of the modern browsers (Firefox, Chrome, Safari, Edge) and IE11

Before:
![before](https://user-images.githubusercontent.com/87611/39668382-928bfabc-50cc-11e8-9435-c5f9f353e8f5.jpg)

After:
![after](https://user-images.githubusercontent.com/87611/39668385-99dbaf38-50cc-11e8-8e19-f955b8649d4e.jpg)

## Notes

There were actually 2 issues when I was implementing that behavior:

1. The lack of stylesheet methodology to be followed. I have added my modifications to the end of the file.
2. For some reason I found that `box-sizing` is following the browser's default and I am not sure if it is a good idea or not. People usually change it to `border-box` to easily calculate the dimensions of the boxes. I had to implement it on a certain block to overcome the collapse being applied to the box caused by the `margin: 0 auto` and `display: flex`. 
